### PR TITLE
WIKIEDITOR-39: Webjars are not loaded in XWiki before 6.3

### DIFF
--- a/editor-tool-highlighting/editor-tool-highlighting-ui-code/src/main/resources/SyntaxHighlighting/Macros.xml
+++ b/editor-tool-highlighting/editor-tool-highlighting-ui-code/src/main/resources/SyntaxHighlighting/Macros.xml
@@ -44,8 +44,8 @@
   <hidden>true</hidden>
   <content>{{velocity output="false"}}
 ## Always ending in '/', remember not to add it twice.
-#set ($codeMirrorBaseURL = $services.webjars.url('codemirror', ''))
-#if ($codeMirrorBaseURL.contains('?'))
+#set ($codeMirrorBaseURL = $services.webjars.url('codemirror'))
+#if ($codeMirrorBaseURL.contains('?') || "$!codeMirrorBaseURL" == "")
   ## Workaround for XWiki versions pre 7.1M1 that do not have http://jira.xwiki.org/browse/XWIKI-10881 fixed so that syntax highlighting works on older versions as well.
   #set ($codeMirrorBaseURL = "${xwiki.getURL('SyntaxHighlighting.RequireJSRequestRouter')}/codemirror/")
 #end

--- a/editor-tool-highlighting/editor-tool-highlighting-ui-code/src/main/resources/SyntaxHighlighting/RequireJSRequestRouter.xml
+++ b/editor-tool-highlighting/editor-tool-highlighting-ui-code/src/main/resources/SyntaxHighlighting/RequireJSRequestRouter.xml
@@ -46,7 +46,17 @@
 #set ($webjarId = $stringtool.substringBefore($resource, '/'))
 #set ($resource = $stringtool.substringAfter($resource, '/'))
 #if ("$!webjarId" != '' &amp;&amp; "$!resource" != '')
-  $response.sendRedirect($services.webjars.url($webjarId, $resource))
+  #if("$!services.webjars.url($webjarId, $resource)" != "")
+    $response.sendRedirect($services.webjars.url($webjarId,$resource))
+  #else
+    ## In XWiki &lt; 6.3, $services.webjars.url() works only with one parameter
+    #set ($extensionsList = $services.extension.installed.getInstalledExtensions().toString())
+    #set ($codemirrorVersion = $stringtool.substringBetween($extensionsList, 'org.webjars:codemirror-', ','))
+    #if(!$stringtool.startWith($resource, '/'))
+      #set ($codemirrorVersion = "$codemirrorVersion/")
+    #end
+    $response.sendRedirect($services.webjars.url("$webjarId/$codemirrorVersion$resource"))
+  #end
 #else
 Routes Webjar resource requests in a way that is compatible with RequireJS relative path dependencies.
 #end


### PR DESCRIPTION
Add a way to load the CodeMirror webjar from XWiki versions older than 6.3