### PR TITLE
Potential null reference leads to NullPointerException

### DIFF
--- a/editor-tool-autocomplete/editor-tool-autocomplete-api/src/main/java/org/xwiki/editor/tool/autocomplete/internal/AutoCompletionResource.java
+++ b/editor-tool-autocomplete/editor-tool-autocomplete-api/src/main/java/org/xwiki/editor/tool/autocomplete/internal/AutoCompletionResource.java
@@ -125,7 +125,7 @@ public class AutoCompletionResource implements XWikiRestComponent
 
         // Only support autocompletion on Velocity ATM
         TargetContent targetContent = this.targetContentLocator.locate(content, syntaxId, offset);
-        if (targetContent.getType() == TargetContentType.VELOCITY) {
+        if (targetContent != null && targetContent.getType() == TargetContentType.VELOCITY) {
             hints = getHints(targetContent.getContent(), targetContent.getPosition());
         }
 


### PR DESCRIPTION
While editing code I would occasionally receive an Internal Server Error and a NPE in the server log.  This happens if the UI code calls the hint API but no velocity macro is found.  Xwiki-rendering doesn't detect the velocity block if it's within another macro such as on the xwiki Main welcome page in 9.11.4:

`{{box cssClass="floatinginfobox"}}
{{velocity}}`

Perhaps this is by design.  Regardless, it was my first exercise in debugging xwiki extensions so I feel like I benefited from the experience.  Thanks for your extension and your time.